### PR TITLE
Update dead links with permalinks and archived versions

### DIFF
--- a/RFC-0000-template.md
+++ b/RFC-0000-template.md
@@ -8,7 +8,7 @@
 - Submit a pull request titled `RFC-00xx-my-feature`. 
     - Assign the `draft` label while composing the RFC. You may find it easier to use a WYSIWYG editor (like Google Docs) when working with a few close collaborators; feel free to use whatever platform you like. Ideally this document is publicly visible and is linked to from the PR.
     - When opening the RFC for general discussion, copy your document into the `RFC-00xx-my-feature.md` file on the PR and assign the `commenting` label.
-- Build consensus for your proposal, integrate feedback and revise it as needed, and summarize the outcome of the discussion via a [resolution template](https://github.com/pytorch/rfcs/blob/rfc-process/RFC-0000-template.md#resolution).
+- Build consensus for your proposal, integrate feedback and revise it as needed, and summarize the outcome of the discussion via a [resolution template](https://github.com/pytorch/rfcs/blob/master/RFC-0000-template.md#resolution).
     - If the RFC is idle here (no activity for 2 weeks), assign the label `stalled` to the PR.
 - Once the discussion has settled, assign a new label based on the level of support:
     - `accepted` if a decision has been made in the RFC

--- a/RFC-0006-conda-distribution.md
+++ b/RFC-0006-conda-distribution.md
@@ -124,7 +124,7 @@ There's more integration testing happening already:
   repo contains tooling to test PyTorch release candidates.
 - An overview of integration test results from the `builder` repo (last updated Oct'19,
   so perhaps no longer maintained) can be found
-  [here](http://ossci-integration-test-results.s3-website-us-east-1.amazonaws.com/test-results.html).
+  [here](https://web.archive.org/web/20201222195552/http://ossci-integration-test-results.s3-website-us-east-1.amazonaws.com/test-results.html).
 
 
 ## Usage and Impact

--- a/RFC-0019-Extending-PyTorch-Quantization-to-Custom-Backends.md
+++ b/RFC-0019-Extending-PyTorch-Quantization-to-Custom-Backends.md
@@ -235,7 +235,7 @@ def lower_to_qnnpack_fx(model: QuantizedGraphModule) -> torch.nn.Module:
 ```
 
 As is shown from the code, there are two requirements that must be met when we add a new lowering pass for a specific backed:
-We need to register the backend quantized operator in `torch.ops` namespace, this can be achieved with PyTorch custom operator registration: https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/native/quantized/cpu/qconv.cpp#L881.
+We need to register the backend quantized operator in `torch.ops` namespace, this can be achieved with PyTorch custom operator registration: https://github.com/pytorch/pytorch/blob/dfbd030854359207cb3040b864614affeace11ce/aten/src/ATen/native/quantized/cpu/qconv.cpp#L881.
 
 ## Use Case 2: Quantizing the Same Model for Inference on Custom Backend
 If a backend does not need to modify the quantization flow, that is, it does not have extra quantized operators, fused quantized operators or customizations of quantization flow, we only need to write a lowering pass to transform a reference quantized model to a model runnable on a custom backend.

--- a/RFC-0024-rfc-process.md
+++ b/RFC-0024-rfc-process.md
@@ -49,7 +49,7 @@ We can easily implement this lifecycle on the existing rfcs repo (https://github
 - Submit a pull request titled `RFC-00xx-my-feature`. 
     - Assign the `draft` label while composing the RFC. You may find it easier to use a WYSIWYG editor (like Google Docs) when working with a few close collaborators; feel free to use whatever platform you like. Ideally this document is publicly visible and is linked to from the PR.
     - When opening the RFC for general discussion, copy your document into the `RFC-00xx-my-feature.md` file on the PR and assign the `commenting` label.
-- Build consensus for your proposal, integrate feedback and revise it as needed, and summarize the outcome of the discussion via a [resolution template](https://github.com/pytorch/rfcs/blob/rfc-process/RFC-0000-template.md#resolution).
+- Build consensus for your proposal, integrate feedback and revise it as needed, and summarize the outcome of the discussion via a [resolution template](https://github.com/pytorch/rfcs/blob/master/RFC-0000-template.md#resolution).
     - If the RFC is idle here (no activity for 2 weeks), assign the label `stalled` to the PR.
 - Once the discussion has settled, assign a new label based on the level of support:
     - `accepted` if a decision has been made in the RFC
@@ -69,7 +69,7 @@ When an RFC is in `commenting`, we can highlight it in a few ways by sharing a w
 * Twitter
 
 ### RFC Template
-The provided [RFC template](https://github.com/pytorch/rfcs/blob/rfc-process/RFC-0000-template.md) contains sections to help draft a detailed RFC, and workflow instructions so that contributors don't need to refer to any other place to understand the process.
+The provided [RFC template](https://github.com/pytorch/rfcs/blob/master/RFC-0000-template.md) contains sections to help draft a detailed RFC, and workflow instructions so that contributors don't need to refer to any other place to understand the process.
 
 ### Advantages of Github as a platform for RFCs:
 * Review comments are threaded, so conversations around a particular sentence are colocated
@@ -121,8 +121,8 @@ When authors open a new PR on the RFCs repo, they are asked to create a document
 ## **Prior Art**
 The proposals in this document are inspired by  
 * [Rust](https://github.com/rust-lang/rfcs) and [React](https://github.com/reactjs/rfcs/) RFC process that use Github, 
-* the Artsy RFC process for the [resolution template](https://github.com/artsy/README/blob/main/playbooks/rfcs.md#resolution), and 
-* the [Sourcegraph RFC](https://handbook.sourcegraph.com/company-info-and-process/communication/rfcs) process that uses Google Docs.
+* the Artsy RFC process for the [resolution template](https://github.com/artsy/README/blob/main/playbooks/rfcs.md#resolve-rfc), and
+* the [Sourcegraph RFC](https://sourcegraph.notion.site/Requests-for-comments-RFCs-3e9cb5c238f04042893d449572ca02bd) process that uses Google Docs.
 
 
 ## Resolution

--- a/RFC-0030-native-fp8-dtype.md
+++ b/RFC-0030-native-fp8-dtype.md
@@ -11,7 +11,7 @@ Since fp8 data type seems to be a natural evolution of currently used fp16/bf16,
 
 * Nvidia, Arm and Intel - https://arxiv.org/pdf/2209.05433.pdf
 * GraphCore, AMD and Qualcomm - https://arxiv.org/pdf/2206.02915.pdf
-* Tesla - https://tesla-cdn.thron.com/static/MXMU3S_tesla-dojo-technology_1WDVZN.pdf
+* Tesla - https://web.archive.org/web/20230503235751/https://tesla-cdn.thron.com/static/MXMU3S_tesla-dojo-technology_1WDVZN.pdf
 
 This RFC proposes adding two 8-bit floating point data types variants to PyTorch, based on the Nvidia/Arm/Intel paper. It’s important to consider these two variants, because they’re already known to be used by Nvidia H100 and Intel Gaudi2 accelerators.
 


### PR DESCRIPTION
RFCs are great artifacts for new people (like myself) who want to learn about certain aspects of the projects.

Unfortunately line-number anchors tend to drift and content gets moved, resulting in dead links. I've updated most of the published RFCs with permalinks and archived versions for the links that resulted in 404s or confusing anchor points.